### PR TITLE
Fixing a bug found during E2169. Testing - Answer Tagging

### DIFF
--- a/app/models/tag_prompt_deployment.rb
+++ b/app/models/tag_prompt_deployment.rb
@@ -11,7 +11,7 @@ class TagPromptDeployment < ActiveRecord::Base
 
   def get_number_of_taggable_answers(user_id)
     team = Team.joins(:teams_users).where(team_users: {parent_id: self.assignment_id}, user_id: user_id)
-    responses = Response.joins(:response_maps).where(response_maps: {reviewed_object_id: self.assignment.id, reviewee_id: team.id})
+    responses = Response.joins(:response_maps).where(response_maps: {reviewed_object_id: self.assignment.id, reviewee_id: team.id}) 
     questions = Question.where(questionnaire_id: self.questionnaire.id, type: self.question_type)
 
     unless responses.empty? || questions.empty?
@@ -20,7 +20,8 @@ class TagPromptDeployment < ActiveRecord::Base
 
       answers = Answer.where(question_id: questions_ids, response_id: responses_ids)
 
-      answers = answers.where(conditions: "length(comments) < " + self.answer_length_threshold) unless self.answer_length_threshold.nil?
+      # E2169. Testing - Answer Tagging
+      answers = answers.where(conditions: "length(comments) < #{self.answer_length_threshold}" ) unless self.answer_length_threshold.nil?
       return answers.count
     end
     0

--- a/app/models/tag_prompt_deployment.rb
+++ b/app/models/tag_prompt_deployment.rb
@@ -11,7 +11,7 @@ class TagPromptDeployment < ActiveRecord::Base
 
   def get_number_of_taggable_answers(user_id)
     team = Team.joins(:teams_users).where(team_users: {parent_id: self.assignment_id}, user_id: user_id)
-    responses = Response.joins(:response_maps).where(response_maps: {reviewed_object_id: self.assignment.id, reviewee_id: team.id}) 
+    responses = Response.joins(:response_maps).where(response_maps: {reviewed_object_id: self.assignment.id, reviewee_id: team.id})
     questions = Question.where(questionnaire_id: self.questionnaire.id, type: self.question_type)
 
     unless responses.empty? || questions.empty?


### PR DESCRIPTION
Fixing type errors found as an additional issue in the source code of tag_prompt_deployment.rb. 

TypeError:
no implicit conversion of Fixnum into String at line 23 https://github.com/expertiza/expertiza/blob/beta/app/models/tag_prompt_deployment.rb.